### PR TITLE
Don't copy framework dependencies

### DIFF
--- a/Bookbinder.xcodeproj/project.pbxproj
+++ b/Bookbinder.xcodeproj/project.pbxproj
@@ -225,8 +225,6 @@
 				25FAE3A722638133003F8214 /* Sources */,
 				25FAE3A822638133003F8214 /* Frameworks */,
 				25FAE3A922638133003F8214 /* Resources */,
-				25728EA32291BA2200DAC525 /* ShellScript */,
-				25728EAD2291F28C00DAC525 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -314,47 +312,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		25728EA32291BA2200DAC525 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/Kanna.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/ZIPFoundation.framework",
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Kanna.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ZIPFoundation.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
-		};
-		25728EAD2291F28C00DAC525 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		25FAE3A722638133003F8214 /* Sources */ = {


### PR DESCRIPTION
Hello!, I found an issue while archiving a project using your library with Carthage, the framework project was using the script `copy-frameworks` this step should be done in the host app instead; it was causing Bookbinder to be added twice to the project, so it will fail to archive.